### PR TITLE
Fix tags and passing data

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+text eol=crlf

--- a/Room Plugin/Room Plugin.csproj
+++ b/Room Plugin/Room Plugin.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DarkRift">
-      <HintPath>..\..\DarkRiftServer\Lib\DarkRift.dll</HintPath>
+      <HintPath>..\..\..\..\tools\DarkRift Server - Free\Lib\DarkRift.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -42,7 +42,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="Transmission">
-      <HintPath>..\..\DarkRiftServer\Lib\Transmission.dll</HintPath>
+      <HintPath>..\..\..\..\tools\DarkRift Server - Free\Lib\Transmission.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
There's a few changes here.

- I'm using `147` as the Room operations tag as that's the number I arbitrarily chose for the Unity example
-- It should still be configurable from a settings file, as the manual suggests, but we can do this at another point
- The `OnData` function checks the `data.subject` property instead of `data.tag` as I believe tags are meant for groups of similar subjects
-- e.g. "Room Operations" is our tag, "Create", "Join", "Leave" would be subjects
- Before exiting the `OnData` function, the NetworkMessage param `data` needs to have its data re-encoded because it's used by other `OnData` functions, so I've done that as well

Registering this as a plugin to the DarkRift server works! I've tested it with the Unity example that I'm going to put online soon :smile: 

Also: the `Room Plugin.csproj` file hasn't actually changed - the line endings are different, is all.