### PR TITLE
Added responses for creating, joining, leaving rooms and disconnecting

### DIFF
--- a/Room Plugin/Room Plugin.csproj
+++ b/Room Plugin/Room Plugin.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Room_Plugin</RootNamespace>
     <AssemblyName>Room Plugin</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -57,7 +58,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Room.cs" />
     <Compile Include="RoomPluginMain.cs" />
-    <Compile Include="Test\RoomTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Room Plugin/packages.config
+++ b/Room Plugin/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.1.1311.0615" targetFramework="net452" />
-  <package id="NUnit" version="3.6.1" targetFramework="net452" />
+  <package id="Moq" version="4.1.1311.0615" targetFramework="net452" requireReinstallation="true" />
+  <package id="NUnit" version="3.6.1" targetFramework="net452" requireReinstallation="true" />
   <package id="NUnit.Console" version="3.6.0" targetFramework="net452" />
   <package id="NUnit.ConsoleRunner" version="3.6.0" targetFramework="net452" />
   <package id="NUnit.Extension.NUnitProjectLoader" version="3.5.0" targetFramework="net452" />


### PR DESCRIPTION
Another hefty one.

- Response messages are sent for: _CreateRoom_, _JoinRoom_, _LeaveRoom_, and when a player disconnects from the server entirely (treated the same as leaving a room)
- Switched build to target .NET 3.5 since that's what Unity requires, so it would be good to avoid using features beyond this version

